### PR TITLE
[cmake] do no export gtest library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(DXT_DATA_BASEDIR "${CMAKE_CURRENT_BINARY_DIR}/data")
 
 # start a dune project with information from dune.module
 dune_project()
-dune_enable_all_packages(INCLUDE_DIRS ${dune-xt-data_SOURCE_DIR}/dune MODULE_LIBRARIES dxt_data gtest_dune_xt_data)
+dune_enable_all_packages(INCLUDE_DIRS ${dune-xt-data_SOURCE_DIR}/dune MODULE_LIBRARIES dxt_data)
 
 # silence warnings from dependent modules
 make_dependent_modules_sys_included()

--- a/dune/xt/data/test/CMakeLists.txt
+++ b/dune/xt/data/test/CMakeLists.txt
@@ -13,7 +13,7 @@
 enable_testing()
 
 include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/gtest)
-dune_library_add_sources(gtest_dune_xt_data SOURCES gtest/gtest-all.cxx)
+add_library(gtest_dune_xt_data gtest/gtest-all.cxx)
 
 dune_add_test(NAME
               test_paths


### PR DESCRIPTION
This avoids linking gtest twice in dune-xt.